### PR TITLE
feat: add terranetes preload for AWS config, add missing SA annotations

### DIFF
--- a/clusterplans/aks-general-purpose.yaml
+++ b/clusterplans/aks-general-purpose.yaml
@@ -15,7 +15,7 @@ spec:
     kubernetesVersion: "1.29"
     packages:
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.10.1-2"
     - name: cert-manager
       version: "1.14.5-1"
     - name: external-dns

--- a/clusterplans/aks-general-purpose.yaml
+++ b/clusterplans/aks-general-purpose.yaml
@@ -23,7 +23,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-2"
+      version: "0.7.18-1"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-general-purpose.yaml
+++ b/clusterplans/aks-general-purpose.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aks-general-purpose
 spec:
   description: General purpose AKS cluster
-  version: "1.0.1"
+  version: "1.0.2"
   provider: AKS
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.12-2"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-sandbox.yaml
+++ b/clusterplans/aks-sandbox.yaml
@@ -15,7 +15,7 @@ spec:
     kubernetesVersion: "1.29"
     packages:
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.10.1-2"
     - name: cert-manager
       version: "1.14.5-1"
     - name: external-dns

--- a/clusterplans/aks-sandbox.yaml
+++ b/clusterplans/aks-sandbox.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aks-sandbox
 spec:
   description: Low cost cluster configuration for testing purposes
-  version: "1.0.1"
+  version: "1.0.2"
   provider: AKS
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.12-2"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-sandbox.yaml
+++ b/clusterplans/aks-sandbox.yaml
@@ -23,7 +23,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-2"
+      version: "0.7.18-1"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-strict.yaml
+++ b/clusterplans/aks-strict.yaml
@@ -15,7 +15,7 @@ spec:
     kubernetesVersion: "1.29"
     packages:
     - name: ingress-nginx-internal
-      version: "4.10.1-2"
+      version: "4.10.1-3"
     - name: cert-manager
       version: "1.14.5-1"
     - name: external-dns-azure-private

--- a/clusterplans/aks-strict.yaml
+++ b/clusterplans/aks-strict.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aks-strict
 spec:
   description: Hardened AKS cluster with a restricted PSS Policy and no public ingress controller
-  version: "1.0.1"
+  version: "1.0.2"
   provider: AKS
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.12-2"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-strict.yaml
+++ b/clusterplans/aks-strict.yaml
@@ -23,7 +23,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-2"
+      version: "0.7.18-1"
 
     providerDetails:
       aks:

--- a/clusterplans/eks-general-purpose.yaml
+++ b/clusterplans/eks-general-purpose.yaml
@@ -33,7 +33,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-2"
+      version: "0.7.18-1"
 
     providerDetails:
       eks:

--- a/clusterplans/eks-general-purpose.yaml
+++ b/clusterplans/eks-general-purpose.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-general-purpose
 spec:
   description: General purpose EKS cluster
-  version: "1.0.1"
+  version: "1.0.2"
   provider: EKS
 
   scope:
@@ -33,7 +33,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.12-2"
 
     providerDetails:
       eks:

--- a/clusterplans/eks-general-purpose.yaml
+++ b/clusterplans/eks-general-purpose.yaml
@@ -25,7 +25,7 @@ spec:
     - name: cluster-autoscaler
       version: "9.36.0-1"
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.10.1-2"
     - name: cert-manager
       version: "1.14.5-1"
     - name: external-dns

--- a/clusterplans/eks-sandbox.yaml
+++ b/clusterplans/eks-sandbox.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-sandbox
 spec:
   description: Low cost cluster configuration for testing purposes
-  version: "1.0.1"
+  version: "1.0.2"
   provider: EKS
 
   scope:
@@ -33,7 +33,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.12-2"
 
     security:
       podSecurityStandard:

--- a/clusterplans/eks-sandbox.yaml
+++ b/clusterplans/eks-sandbox.yaml
@@ -33,7 +33,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-2"
+      version: "0.7.18-1"
 
     security:
       podSecurityStandard:

--- a/clusterplans/eks-sandbox.yaml
+++ b/clusterplans/eks-sandbox.yaml
@@ -25,7 +25,7 @@ spec:
     - name: cluster-autoscaler
       version: "9.36.0-1"
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.10.1-2"
     - name: cert-manager
       version: "1.14.5-1"
     - name: external-dns

--- a/clusterplans/eks-strict.yaml
+++ b/clusterplans/eks-strict.yaml
@@ -33,7 +33,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-2"
+      version: "0.7.18-1"
 
     providerDetails:
       eks:

--- a/clusterplans/eks-strict.yaml
+++ b/clusterplans/eks-strict.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eks-strict
 spec:
   description: Hardened EKS cluster with a restricted PSS Policy and no public ingress controller
-  version: "1.0.1"
+  version: "1.0.2"
   provider: EKS
 
   scope:
@@ -33,7 +33,7 @@ spec:
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.12-2"
 
     providerDetails:
       eks:

--- a/clusterplans/eks-strict.yaml
+++ b/clusterplans/eks-strict.yaml
@@ -25,7 +25,7 @@ spec:
     - name: cluster-autoscaler
       version: "9.36.0-1"
     - name: ingress-nginx-internal
-      version: "4.10.1-2"
+      version: "4.10.1-3"
     - name: cert-manager
       version: "1.14.5-1"
     - name: external-dns

--- a/clusterplans/gke-general-purpose.yaml
+++ b/clusterplans/gke-general-purpose.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-general-purpose
 spec:
   description: General purpose GKE cluster
-  version: "1.0.1"
+  version: "1.0.2"
   provider: GKE
 
   scope:
@@ -15,7 +15,7 @@ spec:
     kubernetesVersion: "1.29"
     packages:
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.10.1-2"
     - name: cert-manager
       version: "1.14.5-1"
     - name: external-dns

--- a/clusterplans/gke-sandbox.yaml
+++ b/clusterplans/gke-sandbox.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-sandbox
 spec:
   description: Low cost cluster configuration for testing purposes
-  version: "1.0.1"
+  version: "1.0.2"
   provider: GKE
 
   scope:
@@ -15,7 +15,7 @@ spec:
     kubernetesVersion: "1.29"
     packages:
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.10.1-2"
     - name: cert-manager
       version: "1.14.5-1"
     - name: external-dns

--- a/clusterplans/gke-strict.yaml
+++ b/clusterplans/gke-strict.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gke-strict
 spec:
   description: Hardened GKE cluster with a restricted PSS Policy and no public ingress controller
-  version: "1.0.1"
+  version: "1.0.2"
   provider: GKE
 
   scope:
@@ -15,7 +15,7 @@ spec:
     kubernetesVersion: "1.29"
     packages:
     - name: ingress-nginx-internal
-      version: "4.10.1-2"
+      version: "4.10.1-3"
     - name: cert-manager
       version: "1.14.5-1"
     - name: external-dns

--- a/packages/ingress-nginx-internal.yaml
+++ b/packages/ingress-nginx-internal.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     appvia.io/displayName: "Internal Ingress Nginx"
 spec:
-  version: "4.10.1-2"
+  version: "4.10.1-3"
   installNamespace: ingress-internal
   description: Enables the capability to provision internal ingress services
 
@@ -47,8 +47,7 @@ spec:
           minReplicas: 2
           targetCPUUtilizationPercentage: 75
           targetMemoryUtilizationPercentage: 70
-        extraArgs:
-          ingress-class: internal
+        ingressClass: internal
         ingressClassResource:
           controllerValue: k8s.io/ingress-nginx-internal
           default: false
@@ -59,7 +58,6 @@ spec:
         replicaCount: 2
         resources:
           limits:
-            cpu: 1000m
             memory: 1024Mi
           requests:
             cpu: 10m

--- a/packages/ingress-nginx.yaml
+++ b/packages/ingress-nginx.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     appvia.io/displayName: "External Ingress Nginx"
 spec:
-  version: "4.10.1-1"
+  version: "4.10.1-2"
   installNamespace: ingress
   description: Enables the capability to provision ingress services
 
@@ -58,7 +58,6 @@ spec:
         replicaCount: 2
         resources:
           limits:
-            cpu: 1000m
             memory: 1024Mi
           requests:
             cpu: 10m

--- a/packages/terranetes-controller.yaml
+++ b/packages/terranetes-controller.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     appvia.io/displayName: "Terranetes Controller"
 spec:
-  version: "0.7.12-2"
+  version: "0.7.18-1"
   installNamespace: terraform-system
   description: Enables the capability to provision cloud resources
 
@@ -13,14 +13,15 @@ spec:
     releaseName: terranetes-controller
     chartName: terranetes-controller
     repositoryRef: wayfinder-builtin
-    chartVersion: "0.7.12"
+    chartVersion: "0.7.18"
     helmTimeout: 300s
   
     valuesTemplate: |
       fullnameOverride: terranetes-controller
       rbac:
         executor:
-          {{ .Package.WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 6 }}
+          annotations:
+            {{ .Package.WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 6 }}
           create: true
       providers:
       - name: default

--- a/packages/terranetes-controller.yaml
+++ b/packages/terranetes-controller.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     appvia.io/displayName: "Terranetes Controller"
 spec:
-  version: "0.7.12-1"
+  version: "0.7.12-2"
   installNamespace: terraform-system
   description: Enables the capability to provision cloud resources
 
@@ -20,12 +20,17 @@ spec:
       fullnameOverride: terranetes-controller
       rbac:
         executor:
-          annotations: {}
+          {{ .Package.WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 6 }}
           create: true
       providers:
       - name: default
       {{- if .Cluster.AWS }}
         provider: aws
+        preload:
+          cluster: {{ .Cluster.AWS.Name }}
+          context: default
+          enabled: true
+          region: {{ .Cluster.Region }}
       {{- end }}
       {{- if .Cluster.Azure }}
         provider: azurerm


### PR DESCRIPTION
**Changes:**
- Terranetes: Add missing Service Account annotations and preload config for AWS
- Ingress: Add missing `internal` Ingress Class spec (for ingress-internal) and remove CPU limits to allow it to spike and use available CPU on Nodes when required.