### PR TITLE
Updates and upstream repos

### DIFF
--- a/clusterplans/aks-general-purpose.yaml
+++ b/clusterplans/aks-general-purpose.yaml
@@ -2,9 +2,11 @@ apiVersion: compute.appvia.io/v2beta2
 kind: ClusterPlan
 metadata:
   name: aks-general-purpose
+  annotations:
+    appvia.io/published: "true"
 spec:
   description: General purpose AKS cluster
-  version: "1.0.1"
+  version: "1.1.0"
   provider: AKS
 
   scope:
@@ -12,18 +14,18 @@ spec:
     allStages: true
 
   cluster:
-    kubernetesVersion: "1.29"
+    kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.11.2-1"
     - name: cert-manager
-      version: "1.14.5-1"
+      version: "1.15.3-1"
     - name: external-dns
-      version: "7.2.1-3"
+      version: "8.3.8-1"
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.20-2"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-general-purpose.yaml
+++ b/clusterplans/aks-general-purpose.yaml
@@ -17,15 +17,15 @@ spec:
     kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx
-      version: "4.11.2-1"
+      version: "4.11.3-1"
     - name: cert-manager
-      version: "1.15.3-1"
+      version: "1.15.3-2"
     - name: external-dns
-      version: "8.3.8-1"
+      version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-5"
+      version: "2.7.3-6"
     - name: terranetes-controller
-      version: "0.7.20-2"
+      version: "0.7.21-1"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-sandbox.yaml
+++ b/clusterplans/aks-sandbox.yaml
@@ -2,9 +2,11 @@ apiVersion: compute.appvia.io/v2beta2
 kind: ClusterPlan
 metadata:
   name: aks-sandbox
+  annotations:
+    appvia.io/published: "true"
 spec:
   description: Low cost cluster configuration for testing purposes
-  version: "1.0.1"
+  version: "1.1.0"
   provider: AKS
 
   scope:
@@ -12,18 +14,18 @@ spec:
     allStages: true
 
   cluster:
-    kubernetesVersion: "1.29"
+    kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.11.2-1"
     - name: cert-manager
-      version: "1.14.5-1"
+      version: "1.15.3-1"
     - name: external-dns
-      version: "7.2.1-3"
+      version: "8.3.8-1"
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.20-2"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-sandbox.yaml
+++ b/clusterplans/aks-sandbox.yaml
@@ -17,15 +17,15 @@ spec:
     kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx
-      version: "4.11.2-1"
+      version: "4.11.3-1"
     - name: cert-manager
-      version: "1.15.3-1"
+      version: "1.15.3-2"
     - name: external-dns
-      version: "8.3.8-1"
+      version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-5"
+      version: "2.7.3-6"
     - name: terranetes-controller
-      version: "0.7.20-2"
+      version: "0.7.21-1"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-strict.yaml
+++ b/clusterplans/aks-strict.yaml
@@ -17,15 +17,15 @@ spec:
     kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx-internal
-      version: "4.11.2-1"
+      version: "4.11.3-1"
     - name: cert-manager
-      version: "1.15.3-1"
+      version: "1.15.3-2"
     - name: external-dns-azure-private
-      version: "8.3.8-1"
+      version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-5"
+      version: "2.7.3-6"
     - name: terranetes-controller
-      version: "0.7.20-2"
+      version: "0.7.21-1"
 
     providerDetails:
       aks:

--- a/clusterplans/aks-strict.yaml
+++ b/clusterplans/aks-strict.yaml
@@ -2,9 +2,11 @@ apiVersion: compute.appvia.io/v2beta2
 kind: ClusterPlan
 metadata:
   name: aks-strict
+  annotations:
+    appvia.io/published: "true"
 spec:
   description: Hardened AKS cluster with a restricted PSS Policy and no public ingress controller
-  version: "1.0.1"
+  version: "1.1.0"
   provider: AKS
 
   scope:
@@ -12,18 +14,18 @@ spec:
     allStages: true
 
   cluster:
-    kubernetesVersion: "1.29"
+    kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx-internal
-      version: "4.10.1-2"
+      version: "4.11.2-1"
     - name: cert-manager
-      version: "1.14.5-1"
+      version: "1.15.3-1"
     - name: external-dns-azure-private
-      version: "7.2.1-2"
+      version: "8.3.8-1"
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.20-2"
 
     providerDetails:
       aks:

--- a/clusterplans/eks-general-purpose.yaml
+++ b/clusterplans/eks-general-purpose.yaml
@@ -2,9 +2,11 @@ apiVersion: compute.appvia.io/v2beta2
 kind: ClusterPlan
 metadata:
   name: eks-general-purpose
+  annotations:
+    appvia.io/published: "true"
 spec:
   description: General purpose EKS cluster
-  version: "1.0.1"
+  version: "1.1.0"
   provider: EKS
 
   scope:
@@ -12,28 +14,28 @@ spec:
     allStages: true
 
   cluster:
-    kubernetesVersion: "1.29"
+    kubernetesVersion: "1.30"
     packages:
     - name: aws-ebs-csi-snapshot-controller
-      version: "2.2.2-1"
+      version: "3.0.6-1"
     - name: aws-ebs-csi-driver
-      version: "2.30.0-1"
+      version: "2.35.1-1"
     - name: tigera-operator
-      version: "3.27.3-1"
+      version: "3.28.2-0"
     - name: metrics-server
       version: "3.12.1-1"
     - name: cluster-autoscaler
-      version: "9.36.0-1"
+      version: "9.37.0-1"
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.11.2-1"
     - name: cert-manager
-      version: "1.14.5-1"
+      version: "1.15.3-1"
     - name: external-dns
-      version: "7.2.1-3"
+      version: "8.3.8-1"
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.20-2"
 
     providerDetails:
       eks:

--- a/clusterplans/eks-general-purpose.yaml
+++ b/clusterplans/eks-general-purpose.yaml
@@ -20,22 +20,24 @@ spec:
       version: "3.0.6-1"
     - name: aws-ebs-csi-driver
       version: "2.35.1-1"
+    - name: aws-load-balancer-controller
+      version: "1.9.0-1"
     - name: tigera-operator
-      version: "3.28.2-0"
+      version: "3.28.2-1"
     - name: metrics-server
-      version: "3.12.1-1"
+      version: "3.12.1-2"
     - name: cluster-autoscaler
-      version: "9.37.0-1"
+      version: "9.43.0-1"
     - name: ingress-nginx
-      version: "4.11.2-1"
+      version: "4.11.3-1"
     - name: cert-manager
-      version: "1.15.3-1"
+      version: "1.15.3-2"
     - name: external-dns
-      version: "8.3.8-1"
+      version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-5"
+      version: "2.7.3-6"
     - name: terranetes-controller
-      version: "0.7.20-2"
+      version: "0.7.21-1"
 
     providerDetails:
       eks:

--- a/clusterplans/eks-sandbox.yaml
+++ b/clusterplans/eks-sandbox.yaml
@@ -2,9 +2,11 @@ apiVersion: compute.appvia.io/v2beta2
 kind: ClusterPlan
 metadata:
   name: eks-sandbox
+  annotations:
+    appvia.io/published: "true"
 spec:
   description: Low cost cluster configuration for testing purposes
-  version: "1.0.1"
+  version: "1.1.0"
   provider: EKS
 
   scope:
@@ -12,28 +14,28 @@ spec:
     allStages: true
 
   cluster:
-    kubernetesVersion: "1.29"
+    kubernetesVersion: "1.30"
     packages:
     - name: aws-ebs-csi-snapshot-controller
-      version: "2.2.2-1"
+      version: "3.0.6-1"
     - name: aws-ebs-csi-driver
-      version: "2.30.0-1"
+      version: "2.35.1-1"
     - name: tigera-operator
-      version: "3.27.3-1"
+      version: "3.28.2-0"
     - name: metrics-server
       version: "3.12.1-1"
     - name: cluster-autoscaler
-      version: "9.36.0-1"
+      version: "9.37.0-1"
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.11.2-1"
     - name: cert-manager
-      version: "1.14.5-1"
+      version: "1.15.3-1"
     - name: external-dns
-      version: "7.2.1-3"
+      version: "8.3.8-1"
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.20-2"
 
     security:
       podSecurityStandard:

--- a/clusterplans/eks-sandbox.yaml
+++ b/clusterplans/eks-sandbox.yaml
@@ -20,22 +20,24 @@ spec:
       version: "3.0.6-1"
     - name: aws-ebs-csi-driver
       version: "2.35.1-1"
+    - name: aws-load-balancer-controller
+      version: "1.9.0-1"
     - name: tigera-operator
-      version: "3.28.2-0"
+      version: "3.28.2-1"
     - name: metrics-server
-      version: "3.12.1-1"
+      version: "3.12.1-2"
     - name: cluster-autoscaler
-      version: "9.37.0-1"
+      version: "9.43.0-1"
     - name: ingress-nginx
-      version: "4.11.2-1"
+      version: "4.11.3-1"
     - name: cert-manager
-      version: "1.15.3-1"
+      version: "1.15.3-2"
     - name: external-dns
-      version: "8.3.8-1"
+      version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-5"
+      version: "2.7.3-6"
     - name: terranetes-controller
-      version: "0.7.20-2"
+      version: "0.7.21-1"
 
     security:
       podSecurityStandard:

--- a/clusterplans/eks-strict.yaml
+++ b/clusterplans/eks-strict.yaml
@@ -2,9 +2,11 @@ apiVersion: compute.appvia.io/v2beta2
 kind: ClusterPlan
 metadata:
   name: eks-strict
+  annotations:
+    appvia.io/published: "true"
 spec:
   description: Hardened EKS cluster with a restricted PSS Policy and no public ingress controller
-  version: "1.0.1"
+  version: "1.1.0"
   provider: EKS
 
   scope:
@@ -12,28 +14,28 @@ spec:
     allStages: true
 
   cluster: 
-    kubernetesVersion: "1.29"
+    kubernetesVersion: "1.30"
     packages:
     - name: aws-ebs-csi-snapshot-controller
-      version: "2.2.2-1"
+      version: "3.0.6-1"
     - name: aws-ebs-csi-driver
-      version: "2.30.0-1"
+      version: "2.35.1-1"
     - name: tigera-operator
-      version: "3.27.3-1"
+      version: "3.28.2-0"
     - name: metrics-server
       version: "3.12.1-1"
     - name: cluster-autoscaler
-      version: "9.36.0-1"
+      version: "9.37.0-1"
     - name: ingress-nginx-internal
-      version: "4.10.1-2"
+      version: "4.11.2-1"
     - name: cert-manager
-      version: "1.14.5-1"
+      version: "1.15.3-1"
     - name: external-dns
-      version: "7.2.1-3"
+      version: "8.3.8-1"
     - name: kyverno
       version: "2.7.3-5"
     - name: terranetes-controller
-      version: "0.7.12-1"
+      version: "0.7.20-2"
 
     providerDetails:
       eks:

--- a/clusterplans/eks-strict.yaml
+++ b/clusterplans/eks-strict.yaml
@@ -20,22 +20,24 @@ spec:
       version: "3.0.6-1"
     - name: aws-ebs-csi-driver
       version: "2.35.1-1"
+    - name: aws-load-balancer-controller
+      version: "1.9.0-1"
     - name: tigera-operator
-      version: "3.28.2-0"
+      version: "3.28.2-1"
     - name: metrics-server
-      version: "3.12.1-1"
+      version: "3.12.1-2"
     - name: cluster-autoscaler
-      version: "9.37.0-1"
+      version: "9.43.0-1"
     - name: ingress-nginx-internal
-      version: "4.11.2-1"
+      version: "4.11.3-1"
     - name: cert-manager
-      version: "1.15.3-1"
+      version: "1.15.3-2"
     - name: external-dns
-      version: "8.3.8-1"
+      version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-5"
+      version: "2.7.3-6"
     - name: terranetes-controller
-      version: "0.7.20-2"
+      version: "0.7.21-1"
 
     providerDetails:
       eks:

--- a/clusterplans/gke-general-purpose.yaml
+++ b/clusterplans/gke-general-purpose.yaml
@@ -2,9 +2,11 @@ apiVersion: compute.appvia.io/v2beta2
 kind: ClusterPlan
 metadata:
   name: gke-general-purpose
+  annotations:
+    appvia.io/published: "true"
 spec:
   description: General purpose GKE cluster
-  version: "1.0.1"
+  version: "1.1.0"
   provider: GKE
 
   scope:
@@ -12,14 +14,14 @@ spec:
     allStages: true
 
   cluster:
-    kubernetesVersion: "1.29"
+    kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.11.2-1"
     - name: cert-manager
-      version: "1.14.5-1"
+      version: "1.15.3-1"
     - name: external-dns
-      version: "7.2.1-3"
+      version: "8.3.8-1"
     - name: kyverno
       version: "2.7.3-5"
 

--- a/clusterplans/gke-general-purpose.yaml
+++ b/clusterplans/gke-general-purpose.yaml
@@ -17,13 +17,13 @@ spec:
     kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx
-      version: "4.11.2-1"
+      version: "4.11.3-1"
     - name: cert-manager
-      version: "1.15.3-1"
+      version: "1.15.3-2"
     - name: external-dns
-      version: "8.3.8-1"
+      version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-5"
+      version: "2.7.3-6"
 
     providerDetails:
       gke:

--- a/clusterplans/gke-sandbox.yaml
+++ b/clusterplans/gke-sandbox.yaml
@@ -2,9 +2,11 @@ apiVersion: compute.appvia.io/v2beta2
 kind: ClusterPlan
 metadata:
   name: gke-sandbox
+  annotations:
+    appvia.io/published: "true"
 spec:
   description: Low cost cluster configuration for testing purposes
-  version: "1.0.1"
+  version: "1.1.0"
   provider: GKE
 
   scope:
@@ -12,14 +14,14 @@ spec:
     allStages: true
 
   cluster:
-    kubernetesVersion: "1.29"
+    kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx
-      version: "4.10.1-1"
+      version: "4.11.2-1"
     - name: cert-manager
-      version: "1.14.5-1"
+      version: "1.15.3-1"
     - name: external-dns
-      version: "7.2.1-3"
+      version: "8.3.8-1"
     - name: kyverno
       version: "2.7.3-5"
 

--- a/clusterplans/gke-sandbox.yaml
+++ b/clusterplans/gke-sandbox.yaml
@@ -17,13 +17,13 @@ spec:
     kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx
-      version: "4.11.2-1"
+      version: "4.11.3-1"
     - name: cert-manager
-      version: "1.15.3-1"
+      version: "1.15.3-2"
     - name: external-dns
-      version: "8.3.8-1"
+      version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-5"
+      version: "2.7.3-6"
 
     providerDetails:
       gke:

--- a/clusterplans/gke-strict.yaml
+++ b/clusterplans/gke-strict.yaml
@@ -2,9 +2,11 @@ apiVersion: compute.appvia.io/v2beta2
 kind: ClusterPlan
 metadata:
   name: gke-strict
+  annotations:
+    appvia.io/published: "true"
 spec:
   description: Hardened GKE cluster with a restricted PSS Policy and no public ingress controller
-  version: "1.0.1"
+  version: "1.1.0"
   provider: GKE
 
   scope:
@@ -12,14 +14,14 @@ spec:
     allStages: true
 
   cluster: 
-    kubernetesVersion: "1.29"
+    kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx-internal
-      version: "4.10.1-2"
+      version: "4.11.2-1"
     - name: cert-manager
-      version: "1.14.5-1"
+      version: "1.15.3-1"
     - name: external-dns
-      version: "7.2.1-3"
+      version: "8.3.8-1"
     - name: kyverno
       version: "2.7.3-5"
 

--- a/clusterplans/gke-strict.yaml
+++ b/clusterplans/gke-strict.yaml
@@ -17,13 +17,13 @@ spec:
     kubernetesVersion: "1.30"
     packages:
     - name: ingress-nginx-internal
-      version: "4.11.2-1"
+      version: "4.11.3-1"
     - name: cert-manager
-      version: "1.15.3-1"
+      version: "1.15.3-2"
     - name: external-dns
-      version: "8.3.8-1"
+      version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-5"
+      version: "2.7.3-6"
 
     providerDetails:
       gke:

--- a/packagerepos/autoscaler.yaml
+++ b/packagerepos/autoscaler.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: autoscaler
+spec:
+  url: https://kubernetes.github.io/autoscaler
+  description: |
+    The official Helm repository for the Kubernetes Autoscaler project

--- a/packagerepos/aws-ebs-csi-driver.yaml
+++ b/packagerepos/aws-ebs-csi-driver.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: aws-ebs-csi-driver
+spec:
+  url: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+  description: |
+    The official Kubernetes SIGs repository for the AWS EBS CSI Driver

--- a/packagerepos/bitnami.yaml
+++ b/packagerepos/bitnami.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: bitnami
+spec:
+  url: https://charts.bitnami.com/bitnami
+  description: |
+    The Bitnami repository for Helm charts including External DNS

--- a/packagerepos/eks-charts.yaml
+++ b/packagerepos/eks-charts.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: eks-charts
+spec:
+  url: https://aws.github.io/eks-charts
+  description: |
+    A collection of EKS Charts including the AWS Load Balancer Controller

--- a/packagerepos/external-secrets.yaml
+++ b/packagerepos/external-secrets.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: external-secrets
+spec:
+  url: https://charts.external-secrets.io
+  description: |
+    The official repository for the External Secrets Operator

--- a/packagerepos/ingress-nginx.yaml
+++ b/packagerepos/ingress-nginx.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: ingress-nginx
+spec:
+  url: https://kubernetes.github.io/ingress-nginx
+  description: |
+    The official repository for Ingress NGINX

--- a/packagerepos/jetstack.yaml
+++ b/packagerepos/jetstack.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: jetstack
+spec:
+  url: https://charts.jetstack.io
+  description: |
+    The official Jetstack repository for Cert Manager charts

--- a/packagerepos/metrics-server.yaml
+++ b/packagerepos/metrics-server.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: metrics-server
+spec:
+  url: https://kubernetes-sigs.github.io/metrics-server/
+  description: |
+    The official Kubernetes SIGs repository for the Metrics Server

--- a/packagerepos/piraeus-charts.yaml
+++ b/packagerepos/piraeus-charts.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: piraeus-charts
+spec:
+  url: https://piraeus.io/helm-charts/
+  description: |
+    Contains a chart for the EBS CSI Snapshot Controller

--- a/packagerepos/projectcalico.yaml
+++ b/packagerepos/projectcalico.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Repository
+metadata:
+  name: projectcalico
+spec:
+  url: https://projectcalico.docs.tigera.io/charts
+  description: |
+    A collection of charts for Project Calico

--- a/packagerepos/wayfinder-builtin.yaml
+++ b/packagerepos/wayfinder-builtin.yaml
@@ -1,8 +1,6 @@
 apiVersion: package.appvia.io/v2beta2
 kind: Repository
 metadata:
-  annotations:
-    appvia.io/createdBy: "Wayfinder"
   name: wayfinder-builtin
 spec:
   url: https://charts.wayfinder.run

--- a/packages/aws-ebs-csi-driver.yaml
+++ b/packages/aws-ebs-csi-driver.yaml
@@ -4,10 +4,11 @@ kind: Package
 metadata:
   name: aws-ebs-csi-driver
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "EBS CSI Storage Driver (AWS)"
 spec:
   description: Provides volumes to EKS clusters using AWS EBS
-  version: "2.30.0-1"
+  version: "2.35.1-1"
   installNamespace: kube-system
   dependencies:
   - aws-ebs-csi-snapshot-controller
@@ -16,7 +17,7 @@ spec:
     repositoryRef: wayfinder-builtin
     releaseName: aws-ebs-csi-driver
     chartName: aws-ebs-csi-driver
-    chartVersion: "2.30.0"
+    chartVersion: "2.35.1"
     valuesTemplate: |
       controller:
         serviceAccount:

--- a/packages/aws-ebs-csi-driver.yaml
+++ b/packages/aws-ebs-csi-driver.yaml
@@ -4,17 +4,16 @@ kind: Package
 metadata:
   name: aws-ebs-csi-driver
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "EBS CSI Storage Driver (AWS)"
 spec:
   description: Provides volumes to EKS clusters using AWS EBS
   version: "2.35.1-1"
   installNamespace: kube-system
   dependencies:
-  - aws-ebs-csi-snapshot-controller
+    - aws-ebs-csi-snapshot-controller
 
   helm:
-    repositoryRef: wayfinder-builtin
+    repositoryRef: aws-ebs-csi-driver
     releaseName: aws-ebs-csi-driver
     chartName: aws-ebs-csi-driver
     chartVersion: "2.35.1"
@@ -28,28 +27,28 @@ spec:
     skipTests: true
 
   manifests:
-  - template: |
-      apiVersion: storage.k8s.io/v1
-      kind: StorageClass
-      metadata:
-        annotations:
-          ### Make the default encrypted storage class
-          storageclass.kubernetes.io/is-default-class: "true"
-        name: gp3
-      parameters:
-        type: gp3
-        encrypted: "true"
-      provisioner: kubernetes.io/aws-ebs
-      reclaimPolicy: Delete
-      volumeBindingMode: WaitForFirstConsumer
-      allowVolumeExpansion: true
+    - template: |
+        apiVersion: storage.k8s.io/v1
+        kind: StorageClass
+        metadata:
+          annotations:
+            ### Make the default encrypted storage class
+            storageclass.kubernetes.io/is-default-class: "true"
+          name: gp3
+        parameters:
+          type: gp3
+          encrypted: "true"
+        provisioner: kubernetes.io/aws-ebs
+        reclaimPolicy: Delete
+        volumeBindingMode: WaitForFirstConsumer
+        allowVolumeExpansion: true
 
   workloadIdentity:
     serviceAccountName: ebs-csi-controller-sa
     role:
       aws:
         iamPolicyARNs:
-        - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+          - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
         customIAMPolicyTemplate: |
           {
             "Version": "2012-10-17",

--- a/packages/aws-ebs-csi-snapshot-controller.yaml
+++ b/packages/aws-ebs-csi-snapshot-controller.yaml
@@ -4,15 +4,16 @@ kind: Package
 metadata:
   name: aws-ebs-csi-snapshot-controller
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "EBS CSI Snapshot Controller (AWS)"
     appvia.io/packageProviderFilter: "EKS"
 spec:
   description: Provides snapshot support to EKS clusters using AWS EBS
-  version: "2.2.2-1"
+  version: "3.0.6-1"
   installNamespace: snapshot-controller
 
   helm:
     releaseName: snapshot-controller
     repositoryRef: wayfinder-builtin
     chartName: snapshot-controller
-    chartVersion: "2.2.2"
+    chartVersion: "3.0.6"

--- a/packages/aws-ebs-csi-snapshot-controller.yaml
+++ b/packages/aws-ebs-csi-snapshot-controller.yaml
@@ -4,7 +4,6 @@ kind: Package
 metadata:
   name: aws-ebs-csi-snapshot-controller
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "EBS CSI Snapshot Controller (AWS)"
     appvia.io/packageProviderFilter: "EKS"
 spec:
@@ -14,6 +13,6 @@ spec:
 
   helm:
     releaseName: snapshot-controller
-    repositoryRef: wayfinder-builtin
+    repositoryRef: piraeus-charts
     chartName: snapshot-controller
     chartVersion: "3.0.6"

--- a/packages/aws-load-balancer-controller.yaml
+++ b/packages/aws-load-balancer-controller.yaml
@@ -1,0 +1,292 @@
+---
+apiVersion: package.appvia.io/v2beta2
+kind: Package
+metadata:
+  name: aws-load-balancer-controller
+  annotations:
+    appvia.io/displayName: "Load Balancer Controller (AWS)"
+spec:
+  description: Load Balancer Controller for AWS
+  version: "1.9.0-1"
+  installNamespace: kube-system
+
+  helm:
+    repositoryRef: eks-charts
+    releaseName: aws-load-balancer-controller
+    chartName: aws-load-balancer-controller
+    chartVersion: "1.9.0"
+    valuesTemplate: |
+      clusterName: {{ .Cluster.Name }}
+      ingressClassParams:
+        create: false
+      createIngressClassResource: false
+      serviceAccount:
+        name: aws-load-balancer-controller
+        annotations:
+      {{ .Package.WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 4 }}
+
+  workloadIdentity:
+    serviceAccountName: aws-load-balancer-controller
+    role:
+      aws:
+        customIAMPolicyTemplate: |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Sid": "ALBC01",
+                "Effect": "Allow",
+                "Action": [
+                  "iam:CreateServiceLinkedRole"
+                ],
+                "Resource": "*",
+                "Condition": {
+                  "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                  }
+                }
+              },
+              {
+                "Sid": "ALBC02",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:DescribeAccountAttributes",
+                  "ec2:DescribeAddresses",
+                  "ec2:DescribeAvailabilityZones",
+                  "ec2:DescribeInternetGateways",
+                  "ec2:DescribeVpcs",
+                  "ec2:DescribeVpcPeeringConnections",
+                  "ec2:DescribeSubnets",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeNetworkInterfaces",
+                  "ec2:DescribeTags",
+                  "ec2:GetCoipPoolUsage",
+                  "ec2:DescribeCoipPools",
+                  "elasticloadbalancing:DescribeLoadBalancers",
+                  "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                  "elasticloadbalancing:DescribeListeners",
+                  "elasticloadbalancing:DescribeListenerCertificates",
+                  "elasticloadbalancing:DescribeSSLPolicies",
+                  "elasticloadbalancing:DescribeRules",
+                  "elasticloadbalancing:DescribeTargetGroups",
+                  "elasticloadbalancing:DescribeTargetGroupAttributes",
+                  "elasticloadbalancing:DescribeTargetHealth",
+                  "elasticloadbalancing:DescribeTags",
+                  "elasticloadbalancing:DescribeTrustStores",
+                  "elasticloadbalancing:DescribeListenerAttributes"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "ALBC03",
+                "Effect": "Allow",
+                "Action": [
+                  "cognito-idp:DescribeUserPoolClient",
+                  "acm:ListCertificates",
+                  "acm:DescribeCertificate",
+                  "iam:ListServerCertificates",
+                  "iam:GetServerCertificate",
+                  "waf-regional:GetWebACL",
+                  "waf-regional:GetWebACLForResource",
+                  "waf-regional:AssociateWebACL",
+                  "waf-regional:DisassociateWebACL",
+                  "wafv2:GetWebACL",
+                  "wafv2:GetWebACLForResource",
+                  "wafv2:AssociateWebACL",
+                  "wafv2:DisassociateWebACL",
+                  "shield:GetSubscriptionState",
+                  "shield:DescribeProtection",
+                  "shield:CreateProtection",
+                  "shield:DeleteProtection"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "ALBC04",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:AuthorizeSecurityGroupIngress",
+                  "ec2:RevokeSecurityGroupIngress"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "ALBC05",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:CreateSecurityGroup"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "ALBC06",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:CreateTags"
+                ],
+                "Resource": "arn:aws:ec2:*:*:security-group/*",
+                "Condition": {
+                  "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                  },
+                  "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                  }
+                }
+              },
+              {
+                "Sid": "ALBC07",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:CreateTags",
+                  "ec2:DeleteTags"
+                ],
+                "Resource": "arn:aws:ec2:*:*:security-group/*",
+                "Condition": {
+                  "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+                }
+              },
+              {
+                "Sid": "ALBC08",
+                "Effect": "Allow",
+                "Action": [
+                  "ec2:AuthorizeSecurityGroupIngress",
+                  "ec2:RevokeSecurityGroupIngress",
+                  "ec2:DeleteSecurityGroup"
+                ],
+                "Resource": "*",
+                "Condition": {
+                  "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+                }
+              },
+              {
+                "Sid": "ALBC09",
+                "Effect": "Allow",
+                "Action": [
+                  "elasticloadbalancing:CreateLoadBalancer",
+                  "elasticloadbalancing:CreateTargetGroup"
+                ],
+                "Resource": "*",
+                "Condition": {
+                  "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                  }
+                }
+              },
+              {
+                "Sid": "ALBC10",
+                "Effect": "Allow",
+                "Action": [
+                  "elasticloadbalancing:CreateListener",
+                  "elasticloadbalancing:DeleteListener",
+                  "elasticloadbalancing:CreateRule",
+                  "elasticloadbalancing:DeleteRule"
+                ],
+                "Resource": "*"
+              },
+              {
+                "Sid": "ALBC11",
+                "Effect": "Allow",
+                "Action": [
+                  "elasticloadbalancing:AddTags",
+                  "elasticloadbalancing:RemoveTags"
+                ],
+                "Resource": [
+                  "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+                ],
+                "Condition": {
+                  "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+                }
+              },
+              {
+                "Sid": "ALBC12",
+                "Effect": "Allow",
+                "Action": [
+                  "elasticloadbalancing:AddTags",
+                  "elasticloadbalancing:RemoveTags"
+                ],
+                "Resource": [
+                  "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+                ]
+              },
+              {
+                "Sid": "ALBC13",
+                "Effect": "Allow",
+                "Action": [
+                  "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                  "elasticloadbalancing:SetIpAddressType",
+                  "elasticloadbalancing:SetSecurityGroups",
+                  "elasticloadbalancing:SetSubnets",
+                  "elasticloadbalancing:DeleteLoadBalancer",
+                  "elasticloadbalancing:ModifyTargetGroup",
+                  "elasticloadbalancing:ModifyTargetGroupAttributes",
+                  "elasticloadbalancing:DeleteTargetGroup",
+                  "elasticloadbalancing:ModifyListenerAttributes"
+                ],
+                "Resource": "*",
+                "Condition": {
+                  "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+                }
+              },
+              {
+                "Sid": "ALBC14",
+                "Effect": "Allow",
+                "Action": [
+                  "elasticloadbalancing:AddTags"
+                ],
+                "Resource": [
+                  "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                      "CreateTargetGroup",
+                      "CreateLoadBalancer"
+                    ]
+                  },
+                  "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                  }
+                }
+              },
+              {
+                "Sid": "ALBC15",
+                "Effect": "Allow",
+                "Action": [
+                  "elasticloadbalancing:RegisterTargets",
+                  "elasticloadbalancing:DeregisterTargets"
+                ],
+                "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+              },
+              {
+                "Sid": "ALBC16",
+                "Effect": "Allow",
+                "Action": [
+                  "elasticloadbalancing:SetWebAcl",
+                  "elasticloadbalancing:ModifyListener",
+                  "elasticloadbalancing:AddListenerCertificates",
+                  "elasticloadbalancing:RemoveListenerCertificates",
+                  "elasticloadbalancing:ModifyRule"
+                ],
+                "Resource": "*"
+              }
+            ]
+          }

--- a/packages/cert-manager.yaml
+++ b/packages/cert-manager.yaml
@@ -1,25 +1,24 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: cert-manager
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Cert Manager"
 spec:
   description: Provides the capability to self-serve certificates
-  version: "1.15.3-1"
+  version: "1.15.3-2"
   installNamespace: cert-manager
 
   helm:
     helmTimeout: 30s
     releaseName: cert-manager
-    repositoryRef: wayfinder-builtin
+    repositoryRef: jetstack
     chartName: cert-manager
     chartVersion: "1.15.3"
     valuesTemplate: |
-      cainjector:
+      crds:
         enabled: true
-        replicaCount: 1
       extraArgs:
       - --dns01-recursive-nameservers-only=true
       fullnameOverride: cert-manager
@@ -29,11 +28,8 @@ spec:
           useAppArmor: false
       ingressShim:
         defaultIssuerKind: ClusterIssuer
-      installCRDs: true
-      replicaCount: 1
       resources:
         limits:
-          cpu: 30m
           memory: 512Mi
         requests:
           cpu: 10m

--- a/packages/cert-manager.yaml
+++ b/packages/cert-manager.yaml
@@ -3,10 +3,11 @@ kind: Package
 metadata:
   name: cert-manager
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Cert Manager"
 spec:
   description: Provides the capability to self-serve certificates
-  version: "1.14.5-1"
+  version: "1.15.3-1"
   installNamespace: cert-manager
 
   helm:
@@ -14,7 +15,7 @@ spec:
     releaseName: cert-manager
     repositoryRef: wayfinder-builtin
     chartName: cert-manager
-    chartVersion: "1.14.5"
+    chartVersion: "1.15.3"
     valuesTemplate: |
       cainjector:
         enabled: true

--- a/packages/cluster-autoscaler.yaml
+++ b/packages/cluster-autoscaler.yaml
@@ -1,27 +1,26 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: cluster-autoscaler
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Cluster Autoscaler"
 spec:
-  version: "9.37.0-1"
+  version: "9.43.0-1"
   installNamespace: kube-system
   description: Enables the ability to scale nodepools based on demand
 
   helm:
     releaseName: cluster-autoscaler
-    repositoryRef: wayfinder-builtin
-    chartVersion: "9.37.0"
+    repositoryRef: autoscaler
+    chartVersion: "9.43.0"
     chartName: cluster-autoscaler
     valuesTemplate: |
       autoDiscovery:
         clusterName: {{ .Cluster.AWS.Name }}
       awsRegion: {{ .Cluster.Region }}
-      cloud-provider: aws
+      cloudProvider: aws
       fullnameOverride: cluster-autoscaler
-      priorityClassName: system-cluster-critical
       rbac:
         create: true
         serviceAccount:
@@ -50,11 +49,14 @@ spec:
                   "autoscaling:DescribeAutoScalingInstances",
                   "autoscaling:DescribeInstances",
                   "autoscaling:DescribeLaunchConfigurations",
+                  "autoscaling:DescribeScalingActivities",
                   "autoscaling:DescribeTags",
                   "autoscaling:SetDesiredCapacity",
                   "autoscaling:TerminateInstanceInAutoScalingGroup",
                   "ec2:DescribeLaunchTemplateVersions",
+                  "ec2:DescribeImages",
                   "ec2:DescribeInstanceTypes",
+                  "ec2:GetInstanceTypesFromInstanceRequirements",
                   "eks:DescribeNodegroup"
                 ],
                 "Resource": "*"

--- a/packages/cluster-autoscaler.yaml
+++ b/packages/cluster-autoscaler.yaml
@@ -3,16 +3,17 @@ kind: Package
 metadata:
   name: cluster-autoscaler
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Cluster Autoscaler"
 spec:
-  version: "9.36.0-1"
+  version: "9.37.0-1"
   installNamespace: kube-system
   description: Enables the ability to scale nodepools based on demand
 
   helm:
     releaseName: cluster-autoscaler
     repositoryRef: wayfinder-builtin
-    chartVersion: "9.36.0"
+    chartVersion: "9.37.0"
     chartName: cluster-autoscaler
     valuesTemplate: |
       autoDiscovery:

--- a/packages/external-dns-azure-private.yaml
+++ b/packages/external-dns-azure-private.yaml
@@ -1,12 +1,12 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: external-dns-azure-private
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "External DNS for Azure (Private)"
 spec:
-  version: "8.3.8-1"
+  version: "8.3.9-1"
   installNamespace: external-dns-private
   description: External DNS for Azure allows Kubernetes to manage DNS zones on Azure Private DNS
 
@@ -15,7 +15,7 @@ spec:
     helmTimeout: 300s
     repositoryRef: wayfinder-builtin
     chartName: external-dns
-    chartVersion: "8.3.8"
+    chartVersion: "8.3.9"
     valuesTemplate: |
       domainFilters:
       {{- range .Cluster.DNSZones }}
@@ -38,7 +38,6 @@ spec:
         apiVersion: v1
       resources:
         limits:
-          cpu: 20m
           memory: 50Mi
         requests:
           cpu: 10m

--- a/packages/external-dns-azure-private.yaml
+++ b/packages/external-dns-azure-private.yaml
@@ -3,9 +3,10 @@ kind: Package
 metadata:
   name: external-dns-azure-private
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "External DNS for Azure (Private)"
 spec:
-  version: "7.2.1-2"
+  version: "8.3.8-1"
   installNamespace: external-dns-private
   description: External DNS for Azure allows Kubernetes to manage DNS zones on Azure Private DNS
 
@@ -14,7 +15,7 @@ spec:
     helmTimeout: 300s
     repositoryRef: wayfinder-builtin
     chartName: external-dns
-    chartVersion: "7.2.1"
+    chartVersion: "8.3.8"
     valuesTemplate: |
       domainFilters:
       {{- range .Cluster.DNSZones }}

--- a/packages/external-dns.yaml
+++ b/packages/external-dns.yaml
@@ -1,21 +1,21 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: external-dns
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "External DNS"
 spec:
   description: External DNS allows Kubernetes to manage DNS zones
-  version: "8.3.8-1"
+  version: "8.3.9-1"
   installNamespace: external-dns
 
   helm:
     releaseName: external-dns
     helmTimeout: 300s
-    repositoryRef: wayfinder-builtin
+    repositoryRef: bitnami
     chartName: external-dns
-    chartVersion: "8.3.8"
+    chartVersion: "8.3.9"
     valuesTemplate: |
       domainFilters:
       {{- range .Cluster.DNSZones }}
@@ -36,7 +36,6 @@ spec:
         apiVersion: v1
       resources:
         limits:
-          cpu: 20m
           memory: 50Mi
         requests:
           cpu: 10m

--- a/packages/external-dns.yaml
+++ b/packages/external-dns.yaml
@@ -3,10 +3,11 @@ kind: Package
 metadata:
   name: external-dns
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "External DNS"
 spec:
   description: External DNS allows Kubernetes to manage DNS zones
-  version: "7.2.1-3"
+  version: "8.3.8-1"
   installNamespace: external-dns
 
   helm:
@@ -14,7 +15,7 @@ spec:
     helmTimeout: 300s
     repositoryRef: wayfinder-builtin
     chartName: external-dns
-    chartVersion: "7.2.1"
+    chartVersion: "8.3.8"
     valuesTemplate: |
       domainFilters:
       {{- range .Cluster.DNSZones }}

--- a/packages/ingress-nginx-internal.yaml
+++ b/packages/ingress-nginx-internal.yaml
@@ -81,6 +81,9 @@ spec:
             {{- else if .Cluster.GCP }}
             networking.gke.io/load-balancer-type: "Internal"
             {{- end }}
+          {{- if not .Cluster.AWS }}
+          externalTrafficPolicy: Local
+          {{- end }}
         updateStrategy:
           rollingUpdate:
             maxUnavailable: 1

--- a/packages/ingress-nginx-internal.yaml
+++ b/packages/ingress-nginx-internal.yaml
@@ -3,9 +3,10 @@ kind: Package
 metadata:
   name: ingress-nginx-internal
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Internal Ingress Nginx"
 spec:
-  version: "4.10.1-2"
+  version: "4.11.2-1"
   installNamespace: ingress-internal
   description: Enables the capability to provision internal ingress services
 
@@ -13,7 +14,7 @@ spec:
     releaseName: ingress-nginx-internal
     chartName: ingress-nginx
     repositoryRef: wayfinder-builtin
-    chartVersion: "4.10.1"
+    chartVersion: "4.11.2"
     # time for a load balancer to be created
     helmTimeout: 300s
 
@@ -47,8 +48,7 @@ spec:
           minReplicas: 2
           targetCPUUtilizationPercentage: 75
           targetMemoryUtilizationPercentage: 70
-        extraArgs:
-          ingress-class: internal
+        ingressClass: internal
         ingressClassResource:
           controllerValue: k8s.io/ingress-nginx-internal
           default: false
@@ -59,7 +59,6 @@ spec:
         replicaCount: 2
         resources:
           limits:
-            cpu: 1000m
             memory: 1024Mi
           requests:
             cpu: 10m

--- a/packages/ingress-nginx-internal.yaml
+++ b/packages/ingress-nginx-internal.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: ingress-nginx-internal
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Internal Ingress Nginx"
 spec:
-  version: "4.11.2-1"
+  version: "4.11.3-1"
   installNamespace: ingress-internal
   description: Enables the capability to provision internal ingress services
 
   helm:
     releaseName: ingress-nginx-internal
     chartName: ingress-nginx
-    repositoryRef: wayfinder-builtin
-    chartVersion: "4.11.2"
+    repositoryRef: ingress-nginx
+    chartVersion: "4.11.3"
     # time for a load balancer to be created
     helmTimeout: 300s
 
@@ -48,6 +48,10 @@ spec:
           minReplicas: 2
           targetCPUUtilizationPercentage: 75
           targetMemoryUtilizationPercentage: 70
+        {{- if .Cluster.AWS }}
+        config:
+          use-proxy-protocol: "true"
+        {{- end }}
         ingressClass: internal
         ingressClassResource:
           controllerValue: k8s.io/ingress-nginx-internal
@@ -56,19 +60,27 @@ spec:
           name: internal
         metrics:
           enabled: true
+        networkPolicy:
+          enabled: true
         replicaCount: 2
         resources:
           limits:
             memory: 1024Mi
           requests:
-            cpu: 10m
-            memory: 32Mi
+            cpu: 100m
+            memory: 100Mi
         service:
           annotations:
-            service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+            {{- if .Cluster.AWS }}
+            service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+            service.beta.kubernetes.io/aws-load-balancer-type: "external"
+            service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
+            service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+            {{- else if .Cluster.Azure }}
             service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+            {{- else if .Cluster.GCP }}
             networking.gke.io/load-balancer-type: "Internal"
-          externalTrafficPolicy: Local
+            {{- end }}
         updateStrategy:
           rollingUpdate:
             maxUnavailable: 1

--- a/packages/ingress-nginx.yaml
+++ b/packages/ingress-nginx.yaml
@@ -76,6 +76,8 @@ spec:
             service.beta.kubernetes.io/aws-load-balancer-type: "external"
             service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
             service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+          {{- else }}
+          externalTrafficPolicy: Local
           {{- end }}
         updateStrategy:
           rollingUpdate:

--- a/packages/ingress-nginx.yaml
+++ b/packages/ingress-nginx.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: ingress-nginx
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "External Ingress Nginx"
 spec:
-  version: "4.11.2-1"
+  version: "4.11.3-1"
   installNamespace: ingress
   description: Enables the capability to provision ingress services
 
   helm:
     releaseName: ingress-nginx
     chartName: ingress-nginx
-    repositoryRef: wayfinder-builtin
-    chartVersion: "4.11.2"
+    repositoryRef: ingress-nginx
+    chartVersion: "4.11.3"
     # time for a load balancer to be created
     helmTimeout: 300s
 
@@ -48,6 +48,10 @@ spec:
           minReplicas: 2
           targetCPUUtilizationPercentage: 75
           targetMemoryUtilizationPercentage: 70
+        {{- if .Cluster.AWS }}
+        config:
+          use-proxy-protocol: "true"
+        {{- end }}
         ingressClass: external
         ingressClassResource:
           controllerValue: k8s.io/ingress-nginx
@@ -56,16 +60,23 @@ spec:
           name: external
         metrics:
           enabled: true
+        networkPolicy:
+          enabled: true
         replicaCount: 2
         resources:
           limits:
             memory: 1024Mi
           requests:
-            cpu: 10m
-            memory: 32Mi
+            cpu: 100m
+            memory: 100Mi
         service:
-          annotations: null
-          externalTrafficPolicy: Local
+          {{- if .Cluster.AWS }}
+          annotations:
+            service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+            service.beta.kubernetes.io/aws-load-balancer-type: "external"
+            service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
+            service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+          {{- end }}
         updateStrategy:
           rollingUpdate:
             maxUnavailable: 1

--- a/packages/ingress-nginx.yaml
+++ b/packages/ingress-nginx.yaml
@@ -3,9 +3,10 @@ kind: Package
 metadata:
   name: ingress-nginx
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "External Ingress Nginx"
 spec:
-  version: "4.10.1-1"
+  version: "4.11.2-1"
   installNamespace: ingress
   description: Enables the capability to provision ingress services
 
@@ -13,7 +14,7 @@ spec:
     releaseName: ingress-nginx
     chartName: ingress-nginx
     repositoryRef: wayfinder-builtin
-    chartVersion: "4.10.1"
+    chartVersion: "4.11.2"
     # time for a load balancer to be created
     helmTimeout: 300s
 
@@ -58,7 +59,6 @@ spec:
         replicaCount: 2
         resources:
           limits:
-            cpu: 1000m
             memory: 1024Mi
           requests:
             cpu: 10m

--- a/packages/kyverno.yaml
+++ b/packages/kyverno.yaml
@@ -3,6 +3,7 @@ kind: Package
 metadata:
   name: kyverno
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Kyverno Policy"
 spec:
   version: "2.7.3-5"

--- a/packages/kyverno.yaml
+++ b/packages/kyverno.yaml
@@ -1,12 +1,12 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: kyverno
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Kyverno Policy"
 spec:
-  version: "2.7.3-5"
+  version: "2.7.3-6"
   installNamespace: kyverno
   description: kyverno in clusters
 

--- a/packages/metrics-server.yaml
+++ b/packages/metrics-server.yaml
@@ -3,6 +3,7 @@ kind: Package
 metadata:
   name: metrics-server
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Metrics Server"
 spec:
   description: Gathers prometheus metrics from the nodes for use with scaling policies

--- a/packages/metrics-server.yaml
+++ b/packages/metrics-server.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: metrics-server
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Metrics Server"
 spec:
   description: Gathers prometheus metrics from the nodes for use with scaling policies
   installNamespace: kube-system
-  version: "3.12.1-1"
+  version: "3.12.1-2"
   dependencies:
-  - tigera-operator
+    - tigera-operator
 
   helm:
     releaseName: metrics-server
-    repositoryRef: wayfinder-builtin
+    repositoryRef: metrics-server
     chartName: metrics-server
     chartVersion: "3.12.1"
     helmTimeout: 300s

--- a/packages/terranetes-controller.yaml
+++ b/packages/terranetes-controller.yaml
@@ -1,12 +1,12 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: terranetes-controller
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Terranetes Controller"
 spec:
-  version: "0.7.20-2"
+  version: "0.7.21-1"
   installNamespace: terraform-system
   description: Enables the capability to provision cloud resources
 
@@ -14,10 +14,13 @@ spec:
     releaseName: terranetes-controller
     chartName: terranetes-controller
     repositoryRef: wayfinder-builtin
-    chartVersion: "0.7.20"
+    chartVersion: "0.7.21"
     helmTimeout: 300s
-  
+
     valuesTemplate: |
+      controller:
+        enableHelmWebhookRegistration: true
+        enableControllerWebhookRegistration: false
       fullnameOverride: terranetes-controller
       rbac:
         executor:

--- a/packages/terranetes-controller.yaml
+++ b/packages/terranetes-controller.yaml
@@ -3,9 +3,10 @@ kind: Package
 metadata:
   name: terranetes-controller
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Terranetes Controller"
 spec:
-  version: "0.7.12-1"
+  version: "0.7.20-2"
   installNamespace: terraform-system
   description: Enables the capability to provision cloud resources
 
@@ -13,19 +14,25 @@ spec:
     releaseName: terranetes-controller
     chartName: terranetes-controller
     repositoryRef: wayfinder-builtin
-    chartVersion: "0.7.12"
+    chartVersion: "0.7.20"
     helmTimeout: 300s
   
     valuesTemplate: |
       fullnameOverride: terranetes-controller
       rbac:
         executor:
-          annotations: {}
+          annotations:
+      {{ .Package.WorkloadIdentity.ServiceAccountAnnotations | toYaml | indent 6 }}
           create: true
       providers:
       - name: default
       {{- if .Cluster.AWS }}
         provider: aws
+        preload:
+          cluster: {{ .Cluster.AWS.Name }}
+          context: default
+          enabled: true
+          region: {{ .Cluster.Region }}
       {{- end }}
       {{- if .Cluster.Azure }}
         provider: azurerm

--- a/packages/tigera-operator.yaml
+++ b/packages/tigera-operator.yaml
@@ -1,20 +1,20 @@
+---
 apiVersion: package.appvia.io/v2beta2
 kind: Package
 metadata:
   name: tigera-operator
   annotations:
-    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Tigera operator"
     appvia.io/packageProviderFilter: "EKS"
 spec:
-  version: "3.28.2-0"
+  version: "3.28.2-1"
   installNamespace: kube-system
   description: Enables the ability to create policies around network traffic
 
   helm:
     releaseName: tigera-operator
     chartName: tigera-operator
-    repositoryRef: wayfinder-builtin
+    repositoryRef: projectcalico
     chartVersion: "v3.28.2"
     valuesTemplate: |
       installation:

--- a/packages/tigera-operator.yaml
+++ b/packages/tigera-operator.yaml
@@ -3,10 +3,11 @@ kind: Package
 metadata:
   name: tigera-operator
   annotations:
+    appvia.io/createdBy: "Wayfinder"
     appvia.io/displayName: "Tigera operator"
     appvia.io/packageProviderFilter: "EKS"
 spec:
-  version: "3.27.3-1"
+  version: "3.28.2-0"
   installNamespace: kube-system
   description: Enables the ability to create policies around network traffic
 
@@ -14,7 +15,12 @@ spec:
     releaseName: tigera-operator
     chartName: tigera-operator
     repositoryRef: wayfinder-builtin
-    chartVersion: "v3.27.3"
+    chartVersion: "v3.28.2"
     valuesTemplate: |
       installation:
         kubernetesProvider: EKS
+        registry: quay.io
+      tigeraOperator:
+        registry: quay.io
+      calicoctl:
+        image: quay.io/calico/ctl


### PR DESCRIPTION
- General package updates
- Point to upstream helm repos for all but kyverno + terranetes
- Terranetes-controller chart now installs and manages the webhook configurations
- AWS switched to using Load Balancer Controller and provisions a Network Load Balancer for ingress