### PR TITLE
Increase memory limit for Kyverno and run in high-availability mode

### DIFF
--- a/clusterplans/aks-default-cert.yaml
+++ b/clusterplans/aks-default-cert.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: General purpose AKS cluster with a valid default certificate for the cluster's dynamic DNS zone
-  version: "1.1.2"
+  version: "1.1.3"
   provider: AKS
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/aks-general-purpose.yaml
+++ b/clusterplans/aks-general-purpose.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: General purpose AKS cluster
-  version: "1.1.2"
+  version: "1.1.3"
   provider: AKS
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/aks-sandbox.yaml
+++ b/clusterplans/aks-sandbox.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: Low cost cluster configuration for testing purposes
-  version: "1.1.2"
+  version: "1.1.3"
   provider: AKS
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/aks-strict.yaml
+++ b/clusterplans/aks-strict.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: Hardened AKS cluster with a restricted PSS Policy and no public ingress controller
-  version: "1.1.2"
+  version: "1.1.3"
   provider: AKS
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: external-dns-azure-private
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/eks-default-cert.yaml
+++ b/clusterplans/eks-default-cert.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: General purpose EKS cluster with a valid default certificate for the cluster's dynamic DNS zone
-  version: 1.0.1
+  version: 1.0.2
   provider: EKS
 
   scope:
@@ -35,7 +35,7 @@ spec:
     - name: external-dns
       version: 8.3.9-1
     - name: kyverno
-      version: 2.7.3-6
+      version: 2.7.3-8
     - name: cluster-rbac
       version: 1.0.0
     providerDetails:

--- a/clusterplans/eks-general-purpose.yaml
+++ b/clusterplans/eks-general-purpose.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: General purpose EKS cluster
-  version: "1.2.2"
+  version: "1.2.3"
   provider: EKS
 
   scope:
@@ -35,7 +35,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/eks-sandbox.yaml
+++ b/clusterplans/eks-sandbox.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: Low cost cluster configuration for testing purposes
-  version: "1.2.2"
+  version: "1.2.3"
   provider: EKS
 
   scope:
@@ -35,7 +35,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/eks-strict.yaml
+++ b/clusterplans/eks-strict.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: Hardened EKS cluster with a restricted PSS Policy and no public ingress controller
-  version: "1.2.2"
+  version: "1.2.3"
   provider: EKS
 
   scope:
@@ -35,7 +35,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/eks-terraform.yaml
+++ b/clusterplans/eks-terraform.yaml
@@ -33,7 +33,7 @@ spec:
     - name: external-dns
       version: 8.3.9-1
     - name: kyverno
-      version: 2.7.3-6
+      version: 2.7.3-8
     - name: cluster-rbac
       version: 1.0.0
     security:
@@ -60,4 +60,4 @@ spec:
   scope:
     allStages: true
     allWorkspaces: true
-  version: 1.2.2
+  version: 1.2.3

--- a/clusterplans/gke-default-cert.yaml
+++ b/clusterplans/gke-default-cert.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: General purpose GKE cluster with a valid default certificate for the cluster's dynamic DNS zone
-  version: "1.0.0"
+  version: "1.0.1"
   provider: GKE
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/gke-general-purpose.yaml
+++ b/clusterplans/gke-general-purpose.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: General purpose GKE cluster
-  version: "1.1.2"
+  version: "1.1.3"
   provider: GKE
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/gke-sandbox.yaml
+++ b/clusterplans/gke-sandbox.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: Low cost cluster configuration for testing purposes
-  version: "1.1.2"
+  version: "1.1.3"
   provider: GKE
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/clusterplans/gke-strict.yaml
+++ b/clusterplans/gke-strict.yaml
@@ -6,7 +6,7 @@ metadata:
     appvia.io/published: "true"
 spec:
   description: Hardened GKE cluster with a restricted PSS Policy and no public ingress controller
-  version: "1.1.2"
+  version: "1.1.3"
   provider: GKE
 
   scope:
@@ -23,7 +23,7 @@ spec:
     - name: external-dns
       version: "8.3.9-1"
     - name: kyverno
-      version: "2.7.3-6"
+      version: "2.7.3-8"
     - name: cluster-rbac
       version: "1.0.0"
 

--- a/packages/kyverno.yaml
+++ b/packages/kyverno.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     appvia.io/displayName: "Kyverno Policy"
 spec:
-  version: "2.7.3-6"
+  version: "2.7.3-8"
   installNamespace: kyverno
   description: kyverno in clusters
 
@@ -27,3 +27,17 @@ spec:
               operator: NotIn
               values:
               - kube-system
+      resources:
+        # Use a higher memory limit than the default as if this is OOMKilled the
+        # cluster can be unusable.
+        limits:
+          memory: 1024Mi
+      # Run in high-availability mode as documented here: https://kyverno.io/docs/installation/methods/#high-availability-installation
+      admissionController:
+        replicas: 3
+      backgroundController:
+        replicas: 2
+      cleanupController:
+        replicas: 2
+      reportsController:
+        replicas: 2


### PR DESCRIPTION
This sometimes fails due to hitting the memory limit, and it would be improved by running in high-availability mode given that it can block all access to the cluster if it fails.

Therefore, increase the memory limit and run it in high-availability mode as per the Kyverno docs - https://kyverno.io/docs/installation/methods/#high-availability-installation